### PR TITLE
Fix typo in example gradle command for executing json-manipulation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is how we will test your solutions!
 #### Via the command line:
 
 Assuming you've installed JDK12 and Gradle 6+, you can invoke Gradle directly by
-doing `gradle :mystery-duplicates:run` or `gradle :json-manipuation:run` on the
+doing `gradle :mystery-duplicates:run` or `gradle :json-manipulation:run` on the
 command line.
 
 #### Please Note:


### PR DESCRIPTION
Typo in the gradle command to run the JSON manipulator task. Figured id fire a quick PR here to help out :)